### PR TITLE
Finish async process if buffer is not match.

### DIFF
--- a/rplugin/python3/deoplete/sources/vim_lsp.py
+++ b/rplugin/python3/deoplete/sources/vim_lsp.py
@@ -83,6 +83,9 @@ class Source(Base):
                 return []
 
             self.request_lsp_completion(server_name, context)
+            return []
+
+        context['is_async'] = False
         return []
 
     def request_lsp_completion(self, server_name, context):


### PR DESCRIPTION
if move to other buffer (eg: defx.nvim, cmdwin), should stop processing async completion.