### PR TITLE
add async.vim in README's requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ deoplete source for vim-lsp
 
 - [deoplete.nvim](https://github.com/Shougo/deoplete.nvim)
 - [vim-lsp](https://github.com/prabirshrestha/vim-lsp)
+- [async.vim](https://github.com/prabirshrestha/async.vim)
 
 ### .vimrc
 


### PR DESCRIPTION
Since there was no description of async.vim in the requirement part of README, it added.