### PR TITLE
Add callback notification

### DIFF
--- a/autoload/deoplete_vim_lsp.vim
+++ b/autoload/deoplete_vim_lsp.vim
@@ -24,4 +24,9 @@ function! s:handle_completion(server_name, opt, ctx, data) abort
     let l:result = a:data['response']['result']
     let g:deoplete#source#vim_lsp#_requested = 1
     let g:deoplete#source#vim_lsp#_results = l:result
+
+    if index(['i', 'ic', 'ix'], mode()) >= 0
+        call deoplete#auto_complete()
+    endif
 endfunction
+


### PR DESCRIPTION
When the server is responded to the client, should refresh pum.

Currently deoplete has `deoplete#auto_complete()` feature.
It can tell `should re-run gather_candidates` to the deoplete.

I'm checked it with the `typescript-language-server`.

NOTE: next version of deoplete will be supports `callback` instead of `polling`.
callback is very simple than polling.
If deoplete is released, I create the PR to supports callback maybe.