### PR TITLE
fix c/cpp with ccls

### DIFF
--- a/rplugin/python3/deoplete/sources/vim_lsp.py
+++ b/rplugin/python3/deoplete/sources/vim_lsp.py
@@ -152,7 +152,7 @@ class Source(Base):
                 word = rec.get('entryName', rec.get('label'))
 
             item = {
-                'word': re.sub(r'\([^)]*\)', '', word),
+                'word': re.split("[\( ]", word)[0],
                 'abbr': rec['label'],
                 'dup': 0,
             }


### PR DESCRIPTION
Fixes incorrect completion for C/CPP with CCLS.

Before it pastes whole function including parameters.

Now it pastes only function name.
