### PR TITLE
fix: conditional for completionProvider capability

### DIFF
--- a/rplugin/python3/deoplete/sources/vim_lsp.py
+++ b/rplugin/python3/deoplete/sources/vim_lsp.py
@@ -46,8 +46,10 @@ class Source(Base):
                     continue
                 self.server_capabilities[server_name] = self.vim.call(
                     'lsp#get_server_capabilities', server_name)
-            if not self.server_capabilities[server_name].get(
-                    'completionProvider', False):
+
+            completion_provider = self.server_capabilities[server_name].get(
+                    'completionProvider', False)
+            if completion_provider is False or completion_provider is None:
                 continue
 
             if self.is_auto_complete():


### PR DESCRIPTION
Hi,

For a long time, I've had a problem with `terraform-ls`.  And I've not had the time before now to debug this.  Fortunately, I was able to locate the issue.

I've located it to be the [following line](https://github.com/lighttiger2505/deoplete-vim-lsp/blob/master/rplugin/python3/deoplete/sources/vim_lsp.py#L49).
```python
if not self.server_capabilities[server_name].get(
        'completionProvider', False):
    continue
```

As reported by the client, `completionProvider` can in fact be an empty dict (`"completionProvider": {}`).  Meaning that the above will return with no candidates because it's interpreted as `False`.

I'm not experienced with Python and I'm not sure if this is the correct way.  I've tested with `terraform-ls`, `gopls`, and `sourcekit-lsp`.  They all seem to work after the change.